### PR TITLE
Adds a simple bootstrap script for a local concourse instance

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+export PROJECT_DIR=${PWD}
+PATH=${PROJECT_DIR}/bin:${PATH}
+SECRETS_DIR=${PROJECT_DIR}/secrets
+
+watch_file "${SECRETS_DIR}/bootstrap.kubeconfig"
+if [ -f "${SECRETS_DIR}/bootstrap.kubeconfig" ] ; then
+  export KUBECONFIG="${SECRETS_DIR}/bootstrap.kubeconfig"  
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+secrets/*
+!secrets/*.enc
+!secrets/README.md
+work/*
+!work/README.md
+state
+.DS_Store
+.terraform
+terraform.tfstate
+terraform.tfstate*.backup

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+concourse_url="http://localhost:8080"
+
+wget -O work/concourse-compose.yml https://concourse-ci.org/docker-compose.yml
+docker-compose -f work/concourse-compose.yml up -d
+
+until $(curl --output /dev/null --silent --fail "${concourse_url}/api/v1/info"); do
+    printf '.'
+    sleep 5
+done
+
+fly -t bootstrap login --concourse-url "${concourse_url}" --team-name main \
+    --username test --password test
+
+open "${concourse_url}"

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -12,5 +12,14 @@ done
 
 fly -t bootstrap login --concourse-url "${concourse_url}" --team-name main \
     --username test --password test
+fly -t bootstrap set-pipeline --pipeline bootstrap-tkg-lab --config ci/pipeline.yml --non-interactive
+fly -t bootstrap unpause-pipeline --pipeline bootstrap-tkg-lab
 
-open "${concourse_url}"
+open "${concourse_url}/teams/main/pipelines/bootstrap-tkg-lab"
+
+echo
+echo
+echo "Login into the Concourse instance in your browser as: "
+echo 
+echo "   Username: test"
+echo "   Password: test"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,13 @@
+jobs:
+  - name: job-hello-world
+    public: true
+    plan:
+      - task: hello-world
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source: {repository: busybox}
+          run:
+            path: echo
+            args: [hello world]


### PR DESCRIPTION
TL;DR
-----

Implements a simple local install of Concourse for bootstrapping

Details
-------

This change adds the `bootstrap` script that starts a local 
Concourse using Docker Compose. Includes a sample pipeline
and loads that pipeline into that Concourse instance and 
opens a browser to it. The sample pipeline will evolve into the
actual bootstrap pipeline.